### PR TITLE
Updated the configuration due to the new version of the bootique library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>io.bootique.bom</groupId>
                 <artifactId>bootique-bom</artifactId>
-                <version>0.24</version>
+                <version>0.25</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -49,6 +49,10 @@
         <dependency>
             <groupId>io.bootique.linkrest</groupId>
             <artifactId>bootique-linkrest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.bootique.jdbc</groupId>
+            <artifactId>bootique-jdbc-hikaricp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.bootique.logback</groupId>

--- a/run.yml
+++ b/run.yml
@@ -1,8 +1,9 @@
 jdbc:
   derby:
-    url: jdbc:derby:target/demodb;create=true
+    jdbcUrl: jdbc:derby:target/demodb;create=true
     driverClassName: org.apache.derby.jdbc.EmbeddedDriver
-    initialSize: 1
+    maximumPoolSize: 1
+    minimumIdle: 1
 
 cayenne:
   datasource: derby


### PR DESCRIPTION
Hi! The old example generated an error with the new library 0.25: - Error running command '--server --config=run.yml': No concrete 'bootique-jdbc' implementation found. You will need to add one (such as 'bootique-jdbc-tomcat', etc.) as an application dependency. 